### PR TITLE
restrict Hue value

### DIFF
--- a/lib/color-hash.js
+++ b/lib/color-hash.js
@@ -67,6 +67,9 @@ var ColorHash = function(options) {
 
     this.L = LS[0];
     this.S = LS[1];
+    
+    this.minH = options.minH;
+    this.maxH = options.maxH;
 
     this.hash = options.hash || BKDRHash;
 };
@@ -83,6 +86,10 @@ ColorHash.prototype.hsl = function(str) {
     var hash = this.hash(str);
 
     H = hash % 359; // note that 359 is a prime
+    if (this.minH && this.maxH){
+      H /= 1000
+      H = H * (this.maxH - this.minH) + this.minH;
+    }
     hash = parseInt(hash / 360);
     S = this.S[hash % this.S.length];
     hash = parseInt(hash / this.S.length);

--- a/lib/color-hash.js
+++ b/lib/color-hash.js
@@ -70,6 +70,10 @@ var ColorHash = function(options) {
     
     this.minH = options.minH;
     this.maxH = options.maxH;
+    if (typeof this.minH === 'undefined' && typeof this.maxH !== 'undefined')
+        this.minH = 0
+    if (typeof this.minH !== 'undefined' && typeof this.maxH === 'undefined')
+        this.maxH = 360
 
     this.hash = options.hash || BKDRHash;
 };
@@ -86,7 +90,7 @@ ColorHash.prototype.hsl = function(str) {
     var hash = this.hash(str);
 
     H = hash % 359; // note that 359 is a prime
-    if (this.minH && this.maxH){
+    if (typeof this.minH !== 'undefined' && typeof this.maxH !== 'undefined'){
       H /= 1000
       H = H * (this.maxH - this.minH) + this.minH;
     }


### PR DESCRIPTION
add the possibility to force generated colors to be in the same _range_ by forcing Hue value in a certain interval
var colorHash = new ColorHash({ minH: 180, maxH: 250 });
