### PR TITLE
Fixed range of Hue when using min a max

### DIFF
--- a/lib/color-hash.js
+++ b/lib/color-hash.js
@@ -91,7 +91,7 @@ ColorHash.prototype.hsl = function(str) {
 
     H = hash % 359; // note that 359 is a prime
     if (typeof this.minH !== 'undefined' && typeof this.maxH !== 'undefined'){
-      H /= 1000
+      H /= 358;
       H = H * (this.maxH - this.minH) + this.minH;
     }
     hash = parseInt(hash / 360);


### PR DESCRIPTION
As `H = hash % 359;` values are in the range of 0 to 358, so you should divide by 358 to get a range from 0 to 1 instead of the previous 0 to 0.358 which lose a lot of range.