### PR TITLE
Recommend npm over bower in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ https://zenozeng.github.io/color-hash/demo/
 ### Browser
 
 ```bash
-bower install color-hash
+npm install color-hash
 ```
 
 A UMD version of ColorHash is located in `dist/`.


### PR DESCRIPTION
Bower is long deprecated and it seems this module is already being published to npm, so recommend that instead.